### PR TITLE
Add service checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ steps:
             - "project:${{ github.repository }}"
 ```
 
+You can also send Datadog service checks from workflows, same as others please note
+how `service-checks` is indeed a string containing YAML code. For example, an use case
+might be sending when a job has failed:
+
+```yaml
+steps:
+  - name: checkout
+    uses: actions/checkout@v2
+  - name: build
+    run: this-will-fail
+  - name: Datadog
+    if: failure()
+    uses: masci/datadog@v1
+    with:
+      api-key: ${{ secrets.DATADOG_API_KEY }}
+      service-checks: |
+        - check: "app.ok"
+          message: "Branch ${{ github.head_ref }} failed to build"
+          status: 0
+          host_name: ${{ github.repository_owner }}
+          tags:
+            - "project:${{ github.repository }}"
+```
+
 ## Development
 
 Install the dependencies
@@ -84,4 +108,4 @@ Ran all test suites.
 ```
 
 When the DD_API_KEY env var is set with a valid API Key, the tests will
-also perform an actual call sending some metrics and events.
+also perform an actual call sending some metrics, events and service checks.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -26,6 +26,7 @@ describe('unit-tests', () => {
     await run()
     expect(dd.sendMetrics).toHaveBeenCalledTimes(0)
     expect(dd.sendEvents).toHaveBeenCalledTimes(0)
+    expect(dd.sendServiceChecks).toHaveBeenCalledTimes(0)
     expect(outSpy).toHaveBeenCalledWith(
       '::error::Run failed: Input required and not supplied: api-key\n'
     )
@@ -63,6 +64,11 @@ describe('unit-tests', () => {
       'fooBarBaz',
       []
     )
+    expect(dd.sendServiceChecks).toHaveBeenCalledWith(
+      'https://api.datadoghq.com',
+      'fooBarBaz',
+      []
+    )
   })
 })
 
@@ -88,6 +94,15 @@ describe('end-to-end tests', () => {
         text: 'Version 1.0.0 is available on Docker Hub',
         alert_type: 'info',
         host: 'example.com'
+      }
+    ])
+    process.env['INPUT_SERVICE-CHECKS'] = yaml.safeDump([
+      {
+        check: 'app.ok',
+        message: 'Build has failed',
+        status: 0,
+        host_name: 'example.com',
+        tags: ['foo:bar']
       }
     ])
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'A list of event objects to send, see docs for details'
     default: '[]'
   service-checks:
-    description: 'A list of serive check objects to send, see docs for details'
+    description: 'A list of service check objects to send, see docs for details'
     default: '[]'
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   events:
     description: 'A list of event objects to send, see docs for details'
     default: '[]'
+  service-checks:
+    description: 'A list of serive check objects to send, see docs for details'
+    default: '[]'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/run.ts
+++ b/src/run.ts
@@ -15,6 +15,11 @@ export async function run(): Promise<void> {
     const events: dd.Event[] =
       (yaml.safeLoad(core.getInput('events')) as dd.Event[]) || []
     await dd.sendEvents(apiURL, apiKey, events)
+
+    const serviceChecks: dd.ServiceCheck[] =
+      (yaml.safeLoad(core.getInput('service-checks')) as dd.ServiceCheck[]) ||
+      []
+    await dd.sendServiceChecks(apiURL, apiKey, serviceChecks)
   } catch (error) {
     core.setFailed(`Run failed: ${error.message}`)
   }


### PR DESCRIPTION
## Description

This PR adds support to send service checks to DataDog.

The API required to send service checks can be viewed here:
https://docs.datadoghq.com/api/latest/service-checks/

## Changes
* Updates the code to add the service-checks in the same way as others
* Updates README.md
* Updates tests