### PR TITLE
Add SendLogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,29 @@ steps:
             - "project:${{ github.repository }}"
 ```
 
+You can also send Datadog logs from workflows, same as others please note
+how `logs` is indeed a string containing YAML code. For example, an use case
+might be sending when a job has failed:
+
+```yaml
+steps:
+  - name: checkout
+    uses: actions/checkout@v2
+  - name: build
+    run: this-will-fail
+  - name: Datadog
+    if: failure()
+    uses: masci/datadog@v1
+    with:
+      api-key: ${{ secrets.DATADOG_API_KEY }}
+      logs: |
+        - ddsource: "nginx"
+          ddtags: "env:staging,version:5.1"
+          hostname: "i-012345678"
+          message: "2019-11-19T14:37:58,995 INFO [process.name][20081] Hello World"
+          service: "payment"
+```
+
 ## Development
 
 Install the dependencies

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -133,11 +133,12 @@ describe('end-to-end tests', () => {
     ])
     process.env['INPUT_LOGS'] = yaml.safeDump([
       {
-        'ddsource': 'nginx',
-        'ddtags': 'env:staging,version:5.1',
-        'hostname': 'i-012345678',
-        'message': '2019-11-19T14:37:58,995 INFO [process.name][20081] Hello World',
-        'service': 'payment'
+        ddsource: 'nginx',
+        ddtags: 'env:staging,version:5.1',
+        hostname: 'i-012345678',
+        message:
+          '2019-11-19T14:37:58,995 INFO [process.name][20081] Hello World',
+        service: 'payment'
       }
     ])
 

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -126,7 +126,6 @@ export async function sendServiceChecks(
   }
 }
 
-
 export async function sendLogs(
   logApiURL: string,
   apiKey: string,
@@ -144,15 +143,11 @@ export async function sendLogs(
     if (res.message.statusCode === undefined || res.message.statusCode >= 400) {
       errors++
       core.error(`HTTP request failed: ${res.message.statusMessage}`)
-      throw new Error(
-        `Failed sending ${errors} out of ${logs.length} events`
-      )
+      throw new Error(`Failed sending ${errors} out of ${logs.length} events`)
     }
   }
 
   if (errors > 0) {
-    throw new Error(
-      `Failed sending ${errors} out of ${logs.length} events`
-    )
+    throw new Error(`Failed sending ${errors} out of ${logs.length} events`)
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,7 +21,7 @@ export async function run(): Promise<void> {
       []
     await dd.sendServiceChecks(apiURL, apiKey, serviceChecks)
 
-    const logApiURL: string = 
+    const logApiURL: string =
       core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com'
     const logs: dd.Log[] =
       (yaml.safeLoad(core.getInput('logs')) as dd.Log[]) || []

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,6 +20,12 @@ export async function run(): Promise<void> {
       (yaml.safeLoad(core.getInput('service-checks')) as dd.ServiceCheck[]) ||
       []
     await dd.sendServiceChecks(apiURL, apiKey, serviceChecks)
+
+    const logApiURL: string = 
+      core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com'
+    const logs: dd.Log[] =
+      (yaml.safeLoad(core.getInput('logs')) as dd.Log[]) || []
+    await dd.sendLogs(logApiURL, apiKey, logs)
   } catch (error) {
     core.setFailed(`Run failed: ${error.message}`)
   }


### PR DESCRIPTION
## Description
This PR adds support to send logs to DataDog.

The API required to send logs can be viewed here:
https://docs.datadoghq.com/api/latest/logs/#send-logs

## Changes
Updates the code to add the logs in the same way as others
Updates README.md
Updates tests