### PR TITLE
Add the capability to read items from a file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,13 +13,25 @@ inputs:
     description: 'A list of metrics objects to send, see docs for details'
     default: '[]'
     required: false
+  metrics-file:
+    description: 'A file path with a list of metrics objects to send, see docs for details'
+    default: ''
+    required: false
   events:
     description: 'A list of event objects to send, see docs for details'
     default: '[]'
     required: false
+  events-file:
+    description: 'A file path with a list of event objects to send, see docs for details'
+    default: ''
+    required: false
   service-checks:
     description: 'A list of service check objects to send, see docs for details'
     default: '[]'
+    required: false
+  service-checks-file:
+    description: 'A file path with a list of service check objects to send, see docs for details'
+    default: ''
     required: false
   log-api-url:
     description: 'The URL of the Log API endpoint, defaults to JSON or plain text format over HTTPS'
@@ -28,6 +40,10 @@ inputs:
   logs:
     description: 'A list of log objects to send, see docs for details'
     default: '[]'
+    required: false
+  logs-file:
+    description: 'A file path with a list of log objects to send, see docs for details'
+    default: ''
     required: false
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -8,21 +8,27 @@ inputs:
   api-url:
     description: 'The URL of the API endpoint, defaults to US datacenter'
     default: 'https://api.datadoghq.com'
+    required: false
   metrics:
     description: 'A list of metrics objects to send, see docs for details'
     default: '[]'
+    required: false
   events:
     description: 'A list of event objects to send, see docs for details'
     default: '[]'
+    required: false
   service-checks:
     description: 'A list of service check objects to send, see docs for details'
     default: '[]'
+    required: false
   log-api-url:
     description: 'The URL of the Log API endpoint, defaults to JSON or plain text format over HTTPS'
     default: 'https://http-intake.logs.datadoghq.com'
+    required: false
   logs:
     description: 'A list of log objects to send, see docs for details'
     default: '[]'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -5337,20 +5337,33 @@ exports.run = void 0;
 const core = __importStar(__webpack_require__(470));
 const dd = __importStar(__webpack_require__(223));
 const yaml = __importStar(__webpack_require__(414));
+const fs = __importStar(__webpack_require__(747));
+const loadFromFile = (filename) => {
+    if (!fs.existsSync(filename))
+        return '';
+    return fs.readFileSync(filename, 'utf8').toString();
+};
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const apiKey = core.getInput('api-key', { required: true });
             const apiURL = core.getInput('api-url') || 'https://api.datadoghq.com';
-            const metrics = yaml.safeLoad(core.getInput('metrics')) || [];
+            const metrics = yaml.safeLoad(loadFromFile(core.getInput('metrics-file'))) ||
+                yaml.safeLoad(core.getInput('metrics')) ||
+                [];
             yield dd.sendMetrics(apiURL, apiKey, metrics);
-            const events = yaml.safeLoad(core.getInput('events')) || [];
+            const events = yaml.safeLoad(loadFromFile(core.getInput('events-file'))) ||
+                yaml.safeLoad(core.getInput('events')) ||
+                [];
             yield dd.sendEvents(apiURL, apiKey, events);
-            const serviceChecks = yaml.safeLoad(core.getInput('service-checks')) ||
+            const serviceChecks = yaml.safeLoad(loadFromFile(core.getInput('service-checks-file'))) ||
+                yaml.safeLoad(core.getInput('service-checks')) ||
                 [];
             yield dd.sendServiceChecks(apiURL, apiKey, serviceChecks);
             const logApiURL = core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com';
-            const logs = yaml.safeLoad(core.getInput('logs')) || [];
+            const logs = yaml.safeLoad(loadFromFile(core.getInput('logs-file'))) ||
+                yaml.safeLoad(core.getInput('logs')) ||
+                [];
             yield dd.sendLogs(logApiURL, apiKey, logs);
         }
         catch (error) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,7 +1,13 @@
 import * as core from '@actions/core'
 import * as dd from './datadog'
 import * as yaml from 'js-yaml'
+import * as fs from 'fs'
 
+const loadFromFile = (filename: string): string => {
+  if (!filename || !fs.existsSync(filename)) return ''
+
+  return fs.readFileSync(filename, 'utf8').toString()
+}
 export async function run(): Promise<void> {
   try {
     const apiKey: string = core.getInput('api-key', {required: true})
@@ -9,14 +15,25 @@ export async function run(): Promise<void> {
       core.getInput('api-url') || 'https://api.datadoghq.com'
 
     const metrics: dd.Metric[] =
-      (yaml.safeLoad(core.getInput('metrics')) as dd.Metric[]) || []
+      (yaml.safeLoad(
+        loadFromFile(core.getInput('metrics-file'))
+      ) as dd.Metric[]) ||
+      (yaml.safeLoad(core.getInput('metrics')) as dd.Metric[]) ||
+      []
     await dd.sendMetrics(apiURL, apiKey, metrics)
 
     const events: dd.Event[] =
-      (yaml.safeLoad(core.getInput('events')) as dd.Event[]) || []
+      (yaml.safeLoad(
+        loadFromFile(core.getInput('events-file'))
+      ) as dd.Event[]) ||
+      (yaml.safeLoad(core.getInput('events')) as dd.Event[]) ||
+      []
     await dd.sendEvents(apiURL, apiKey, events)
 
     const serviceChecks: dd.ServiceCheck[] =
+      (yaml.safeLoad(
+        loadFromFile(core.getInput('service-checks-file'))
+      ) as dd.ServiceCheck[]) ||
       (yaml.safeLoad(core.getInput('service-checks')) as dd.ServiceCheck[]) ||
       []
     await dd.sendServiceChecks(apiURL, apiKey, serviceChecks)
@@ -24,7 +41,9 @@ export async function run(): Promise<void> {
     const logApiURL: string =
       core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com'
     const logs: dd.Log[] =
-      (yaml.safeLoad(core.getInput('logs')) as dd.Log[]) || []
+      (yaml.safeLoad(loadFromFile(core.getInput('logs-file'))) as dd.Log[]) ||
+      (yaml.safeLoad(core.getInput('logs')) as dd.Log[]) ||
+      []
     await dd.sendLogs(logApiURL, apiKey, logs)
   } catch (error) {
     core.setFailed(`Run failed: ${error.message}`)


### PR DESCRIPTION
Add the capability to read items from a file

Nowadays, it is really difficult to configure this GitHub action, if you
have many events, logs, metrics, check to push to DataDog.
On the other hand, if the list of items is generated dynamically, then
you have to fight to generate a valid yaml string.

This commit adds the capability to configure a source yaml file to read
the items from.