### PR TITLE
Update Node runtime used to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'A list of log objects to send, see docs for details'
     default: '[]'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'bar-chart-2'


### PR DESCRIPTION
Node 12 has been end-of-life since April (see [here](https://nodejs.org/es/blog/release/v12.13.0/)), and is now being deprecated by GitHub Actions (see [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)). This PR bumps the version of Node using by this Action to 16, which is the latest LTS version.