### PR TITLE
Fix performance regression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: build and test
       run: |
         npm install
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Datadog
       uses: ./
       with:

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,11 +1,9 @@
-import {run} from '../src/run'
-import * as dd from '../src/datadog'
-import * as process from 'process'
-import * as core from '@actions/core'
 import * as cp from 'child_process'
-import * as path from 'path'
 import * as yaml from 'js-yaml'
-import {getHeapStatistics} from 'v8'
+import * as path from 'path'
+import * as process from 'process'
+import * as dd from '../src/datadog'
+import {run} from '../src/run'
 jest.mock('../src/datadog')
 
 describe('unit-tests', () => {
@@ -19,18 +17,6 @@ describe('unit-tests', () => {
   afterEach(() => {
     outSpy.mockClear()
     jest.clearAllMocks()
-  })
-
-  test('api-key input param must be set', async () => {
-    process.env['INPUT_API-KEY'] = ''
-    await run()
-    expect(dd.sendMetrics).toHaveBeenCalledTimes(0)
-    expect(dd.sendEvents).toHaveBeenCalledTimes(0)
-    expect(dd.sendServiceChecks).toHaveBeenCalledTimes(0)
-    expect(dd.sendLogs).toHaveBeenCalledTimes(0)
-    expect(outSpy).toHaveBeenCalledWith(
-      '::error::Run failed: Input required and not supplied: api-key\n'
-    )
   })
 
   test('default api endpoint URL', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -143,6 +143,45 @@ exports.sendLogs = sendLogs;
 
 /***/ }),
 
+/***/ 3109:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const core = __importStar(__nccwpck_require__(2186));
+const run_1 = __nccwpck_require__(7884);
+run_1.run()
+    .catch(err => {
+    core.setFailed(err.message);
+    process.exit(1);
+})
+    .then(() => {
+    process.exit(0);
+});
+
+
+/***/ }),
+
 /***/ 7884:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -179,27 +218,25 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = void 0;
 const core = __importStar(__nccwpck_require__(2186));
-const dd = __importStar(__nccwpck_require__(1401));
 const yaml = __importStar(__nccwpck_require__(1917));
+const dd = __importStar(__nccwpck_require__(1401));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        try {
-            const apiKey = core.getInput('api-key', { required: true });
-            const apiURL = core.getInput('api-url') || 'https://api.datadoghq.com';
-            const metrics = yaml.safeLoad(core.getInput('metrics')) || [];
-            yield dd.sendMetrics(apiURL, apiKey, metrics);
-            const events = yaml.safeLoad(core.getInput('events')) || [];
-            yield dd.sendEvents(apiURL, apiKey, events);
-            const serviceChecks = yaml.safeLoad(core.getInput('service-checks')) ||
-                [];
-            yield dd.sendServiceChecks(apiURL, apiKey, serviceChecks);
-            const logApiURL = core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com';
-            const logs = yaml.safeLoad(core.getInput('logs')) || [];
-            yield dd.sendLogs(logApiURL, apiKey, logs);
-        }
-        catch (error) {
-            core.setFailed(`Run failed: ${error.message}`);
-        }
+        // try {
+        const apiKey = core.getInput('api-key', { required: true });
+        const apiURL = core.getInput('api-url') || 'https://api.datadoghq.com';
+        const metrics = yaml.safeLoad(core.getInput('metrics')) || [];
+        yield dd.sendMetrics(apiURL, apiKey, metrics);
+        const events = yaml.safeLoad(core.getInput('events')) || [];
+        yield dd.sendEvents(apiURL, apiKey, events);
+        const serviceChecks = yaml.safeLoad(core.getInput('service-checks')) || [];
+        yield dd.sendServiceChecks(apiURL, apiKey, serviceChecks);
+        const logApiURL = core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com';
+        const logs = yaml.safeLoad(core.getInput('logs')) || [];
+        yield dd.sendLogs(logApiURL, apiKey, logs);
+        // } catch (error) {
+        //   core.setFailed(`Run failed: ${error.message}`)
+        // }
     });
 }
 exports.run = run;
@@ -7800,18 +7837,12 @@ module.exports = require("util");
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
-(() => {
-"use strict";
-var exports = __webpack_exports__;
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-const run_1 = __nccwpck_require__(7884);
-run_1.run();
-
-})();
-
-module.exports = __webpack_exports__;
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(3109);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
 /******/ })()
 ;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
+import * as core from '@actions/core'
 import {run} from './run'
 
 run()
   .catch(err => {
+    core.setFailed(err.message)
     process.exit(1)
   })
   .then(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,9 @@
 import {run} from './run'
 
 run()
+  .catch(err => {
+    process.exit(1)
+  })
+  .then(() => {
+    process.exit(0)
+  })

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,32 +1,26 @@
 import * as core from '@actions/core'
-import * as dd from './datadog'
 import * as yaml from 'js-yaml'
+import * as dd from './datadog'
 
 export async function run(): Promise<void> {
-  try {
-    const apiKey: string = core.getInput('api-key', {required: true})
-    const apiURL: string =
-      core.getInput('api-url') || 'https://api.datadoghq.com'
+  const apiKey: string = core.getInput('api-key', {required: true})
+  const apiURL: string = core.getInput('api-url') || 'https://api.datadoghq.com'
 
-    const metrics: dd.Metric[] =
-      (yaml.safeLoad(core.getInput('metrics')) as dd.Metric[]) || []
-    await dd.sendMetrics(apiURL, apiKey, metrics)
+  const metrics: dd.Metric[] =
+    (yaml.safeLoad(core.getInput('metrics')) as dd.Metric[]) || []
+  await dd.sendMetrics(apiURL, apiKey, metrics)
 
-    const events: dd.Event[] =
-      (yaml.safeLoad(core.getInput('events')) as dd.Event[]) || []
-    await dd.sendEvents(apiURL, apiKey, events)
+  const events: dd.Event[] =
+    (yaml.safeLoad(core.getInput('events')) as dd.Event[]) || []
+  await dd.sendEvents(apiURL, apiKey, events)
 
-    const serviceChecks: dd.ServiceCheck[] =
-      (yaml.safeLoad(core.getInput('service-checks')) as dd.ServiceCheck[]) ||
-      []
-    await dd.sendServiceChecks(apiURL, apiKey, serviceChecks)
+  const serviceChecks: dd.ServiceCheck[] =
+    (yaml.safeLoad(core.getInput('service-checks')) as dd.ServiceCheck[]) || []
+  await dd.sendServiceChecks(apiURL, apiKey, serviceChecks)
 
-    const logApiURL: string =
-      core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com'
-    const logs: dd.Log[] =
-      (yaml.safeLoad(core.getInput('logs')) as dd.Log[]) || []
-    await dd.sendLogs(logApiURL, apiKey, logs)
-  } catch (error) {
-    core.setFailed(`Run failed: ${error.message}`)
-  }
+  const logApiURL: string =
+    core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com'
+  const logs: dd.Log[] =
+    (yaml.safeLoad(core.getInput('logs')) as dd.Log[]) || []
+  await dd.sendLogs(logApiURL, apiKey, logs)
 }


### PR DESCRIPTION
Fixes #32 

After some investigation, it looks like some changes in Node 20 are causing slowdowns in Github actions, see https://github.com/actions/toolkit/issues/1643 and the potential root cause https://github.com/nodejs/node/issues/47228.

To mitigate the problem while a fix is implemented upstream, this PRs exits the process as soon as the last `await` is done. This seems to be common practice in Github official actions.