### PR TITLE
feat: let user configure timeout and proper manage timeout errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ steps:
     # Default: false
     ignore-timeouts:
 
+    # Timeout value in milliseconds for the HTTP client.
+    # Type: number
+    # Default: 30000 (30 seconds)
+    timeout:
+
     # A list of metric objects to send, defined in YAML format
     # Type: string
     # Default: '[]'

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -25,7 +25,8 @@ describe('unit-tests', () => {
       'https://api.datadoghq.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
   })
 
@@ -36,7 +37,8 @@ describe('unit-tests', () => {
       'http://example.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
     process.env['INPUT_API-URL'] = ''
   })
@@ -47,7 +49,8 @@ describe('unit-tests', () => {
       'https://http-intake.logs.datadoghq.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
   })
 
@@ -58,7 +61,8 @@ describe('unit-tests', () => {
       'http://example.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
     process.env['INPUT_LOG-API-URL'] = ''
   })
@@ -69,25 +73,29 @@ describe('unit-tests', () => {
       'https://api.datadoghq.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
     expect(dd.sendEvents).toHaveBeenCalledWith(
       'https://api.datadoghq.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
     expect(dd.sendServiceChecks).toHaveBeenCalledWith(
       'https://api.datadoghq.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
     expect(dd.sendLogs).toHaveBeenCalledWith(
       'https://http-intake.logs.datadoghq.com',
       'fooBarBaz',
       [],
-      false
+      false,
+      30000
     )
   })
 })
@@ -140,6 +148,37 @@ describe('end-to-end tests', () => {
         message:
           '2019-11-19T14:37:58,995 INFO [process.name][20081] Hello World',
         service: 'payment'
+      }
+    ])
+
+    const ip = path.join(__dirname, '..', 'lib', 'main.js')
+    const options: cp.ExecSyncOptions = {
+      env: process.env
+    }
+
+    try {
+      console.log(cp.execSync(`node ${ip}`, options).toString())
+    } catch (e) {
+      console.log(e.output.toString())
+      throw e
+    }
+  })
+  it('does not fail on timeout errors', () => {
+    process.env['INPUT_API-KEY'] = process.env['DD_API_KEY'] || ''
+    if (process.env['INPUT_API-KEY'] === '') {
+      return
+    }
+    process.env['INPUT_IGNORE-TIMEOUTS'] = 'true'
+    // Set an impossibly low timeout in order to force a client failure
+    process.env['INPUT_TIMEOUT'] = '10'
+
+    process.env['INPUT_METRICS'] = yaml.safeDump([
+      {
+        type: 'count',
+        name: 'test.builds.count',
+        value: 1.0,
+        tags: ['foo:bar'],
+        host: 'example.com'
       }
     ])
 

--- a/__tests__/timeout.test.ts
+++ b/__tests__/timeout.test.ts
@@ -1,0 +1,42 @@
+import * as cp from 'child_process'
+import * as yaml from 'js-yaml'
+import * as path from 'path'
+import * as process from 'process'
+import * as dd from '../src/datadog'
+import {run} from '../src/run'
+jest.mock('@actions/http-client')
+
+describe('Datadog client timeout tests', () => {
+  it('should handle timeout errors correctly in sendMetrics', async () => {
+    // Mock the http client to simulate a timeout
+    const mockPost = jest.fn().mockImplementation(() => {
+      return new Promise((_, reject) => {
+        // Simulate a timeout error
+        reject(new Error('Request timeout: /api/v1/series'))
+      })
+    })
+
+    // Mock the HttpClient constructor
+    require('@actions/http-client').HttpClient.mockImplementation(() => ({
+      post: mockPost
+    }))
+
+    const metric: dd.Metric = {
+      type: 'gauge',
+      name: 'test.metric',
+      value: 1,
+      tags: ['test:true'],
+      host: 'test-host'
+    }
+
+    // Test with ignoreTimeouts = true
+    await expect(
+      dd.sendMetrics('http://api.url', 'fake-key', [metric], true, 30000)
+    ).resolves.not.toThrow()
+
+    // Test with ignoreTimeouts = false
+    await expect(
+      dd.sendMetrics('http://api.url', 'fake-key', [metric], false, 30000)
+    ).rejects.toThrow('Request timeout: /api/v1/series')
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Ignore timeout errors and continue execution'
     required: false
     default: 'false'
+  timeout:
+    description: 'Timeout in milliseconds for the HTTP client'
+    required: false
+    default: '30'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -58,7 +58,7 @@ function postMetricsIfAny(http, apiURL, metrics, endpoint, ignoreTimeouts) {
         // POST data
         if (metrics.series.length) {
             try {
-                core.debug(`About to send ${metrics.series.length} metrics ${ignoreTimeouts}`);
+                core.debug(`About to send ${metrics.series.length} metrics to ${apiURL}/api/${endpoint}`);
                 const res = yield http.post(`${apiURL}/api/${endpoint}`, JSON.stringify(metrics));
                 if (res.message.statusCode === undefined ||
                     res.message.statusCode >= 400) {
@@ -104,7 +104,7 @@ function sendEvents(apiURL, apiKey, events, ignoreTimeouts, timeout) {
     return __awaiter(this, void 0, void 0, function* () {
         const http = getClient(apiKey, timeout);
         let errors = 0;
-        core.debug(`About to send ${events.length} events`);
+        core.debug(`About to send ${events.length} events to ${apiURL}/api/v1/events`);
         for (const ev of events) {
             try {
                 const res = yield http.post(`${apiURL}/api/v1/events`, JSON.stringify(ev));
@@ -132,7 +132,7 @@ function sendServiceChecks(apiURL, apiKey, serviceChecks, ignoreTimeouts, timeou
     return __awaiter(this, void 0, void 0, function* () {
         const http = getClient(apiKey, timeout);
         let errors = 0;
-        core.debug(`About to send ${serviceChecks.length} service checks`);
+        core.debug(`About to send ${serviceChecks.length} service checks to ${apiURL}/api/v1/check_run`);
         for (const sc of serviceChecks) {
             try {
                 const res = yield http.post(`${apiURL}/api/v1/check_run`, JSON.stringify(sc));
@@ -160,7 +160,7 @@ function sendLogs(logApiURL, apiKey, logs, ignoreTimeouts, timeout) {
     return __awaiter(this, void 0, void 0, function* () {
         const http = getClient(apiKey, timeout);
         let errors = 0;
-        core.debug(`About to send ${logs.length} logs`);
+        core.debug(`About to send ${logs.length} logs to ${logApiURL}/v1/input`);
         for (const log of logs) {
             try {
                 const res = yield http.post(`${logApiURL}/v1/input`, JSON.stringify(log));

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,23 +5,30 @@ import * as dd from './datadog'
 export async function run(): Promise<void> {
   const apiKey: string = core.getInput('api-key', {required: true})
   const apiURL: string = core.getInput('api-url') || 'https://api.datadoghq.com'
-  const ignoreTimeouts: boolean = core.getInput('ignore-timeouts') === 'false'
+  const ignoreTimeouts: boolean = core.getInput('ignore-timeouts') === 'true'
+  const timeout: number = parseInt(core.getInput('timeout')) || 30000
 
   const metrics: dd.Metric[] =
     (yaml.safeLoad(core.getInput('metrics')) as dd.Metric[]) || []
-  await dd.sendMetrics(apiURL, apiKey, metrics, ignoreTimeouts)
+  await dd.sendMetrics(apiURL, apiKey, metrics, ignoreTimeouts, timeout)
 
   const events: dd.Event[] =
     (yaml.safeLoad(core.getInput('events')) as dd.Event[]) || []
-  await dd.sendEvents(apiURL, apiKey, events, ignoreTimeouts)
+  await dd.sendEvents(apiURL, apiKey, events, ignoreTimeouts, timeout)
 
   const serviceChecks: dd.ServiceCheck[] =
     (yaml.safeLoad(core.getInput('service-checks')) as dd.ServiceCheck[]) || []
-  await dd.sendServiceChecks(apiURL, apiKey, serviceChecks, ignoreTimeouts)
+  await dd.sendServiceChecks(
+    apiURL,
+    apiKey,
+    serviceChecks,
+    ignoreTimeouts,
+    timeout
+  )
 
   const logApiURL: string =
     core.getInput('log-api-url') || 'https://http-intake.logs.datadoghq.com'
   const logs: dd.Log[] =
     (yaml.safeLoad(core.getInput('logs')) as dd.Log[]) || []
-  await dd.sendLogs(logApiURL, apiKey, logs, ignoreTimeouts)
+  await dd.sendLogs(logApiURL, apiKey, logs, ignoreTimeouts, timeout)
 }


### PR DESCRIPTION
Add a new `timeout` configuration option for the HTTP client, defaults to 30 seconds.

Fixes #35